### PR TITLE
CI: treat warnings as errors.

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -29,7 +29,7 @@ jobs:
           rustup component add clippy
 
       - name: Build
-        run: cargo build --verbose
+        run: RUSTFLAGS=-Dwarnings cargo build --all-features --all-targets --verbose
 
       - name: Verify target directory exists
         run: |


### PR DESCRIPTION
## Content

Treat build warnings as errors. Additionally, build all targets (tests / benchmark / etc) and features (currently we don't use this).