### PR TITLE
CI: enable additional build warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ categories = ["cryptography"]
 include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lints.rust]
+missing_docs = "warn"
+unsafe_code = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
-
+//! An implementation of Approximate Lower Bound Arguments
+//! (ALBA, <https://eprint.iacr.org/2023/1655.pdf>).


### PR DESCRIPTION
## Content

Add additional build warnings given in the style guide we use https://input-output-hk.github.io/catalyst-core/main/06_rust_api/rust_style_guide.html.