### PR TITLE
CI: enable clippy.

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,6 +1,9 @@
 name: Rust CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,9 +39,11 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
-#      - name: Run Clippy
-#        run: cargo clippy -- -D warnings
-#        working-directory: caledonia
+      - name: Run Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --all-targets
 
       - name: Check format
         run: cargo fmt -- --check


### PR DESCRIPTION
## Content

Enable clippy. The findings (both warnings and errors) will be displayed in the "Files changed" tab.
![Screenshot 2024-10-28 at 16-02-11 Tolik_enable clippy test by tolikzinovyev · Pull Request #43 · cardano-scaling_alba](https://github.com/user-attachments/assets/42525a84-b5b5-4517-a072-dacfa685546c)

This PR also restricts CI on git push only to `main` branch. This is because otherwise the findings in the "Files changed" tab are duplicated.