### PR TITLE
Configure clippy lints.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,17 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 [lints.rust]
 missing_docs = "warn"
 unsafe_code = "warn"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+arithmetic_side_effects = "deny"
+cast_possible_truncation = "allow"
+cast_precision_loss = "allow"
+cast_sign_loss = "allow"
+derive_partial_eq_without_eq = "allow"
+doc_markdown = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+semicolon_if_nothing_returned = "deny"
+similar_names = "allow"


### PR DESCRIPTION
## Content

1. `pedantic` lints produce warnings by default
2. some most annoying lints are ignored
3. some lints make clippy fail; e.g. `arithmetic_side_effects` that is the new name for `integer_arithmetic` taken from https://input-output-hk.github.io/catalyst-core/main/06_rust_api/rust_style_guide.html