### PR TITLE
More build warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,19 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 
 [lints.rust]
+missing-copy-implementations = "warn"
+missing-debug-implementations = "warn"
 missing_docs = "warn"
+non-ascii-idents = "forbid"
+redundant-imports = "warn"
+redundant-lifetimes = "warn"
+unit-bindings = "warn"
+unnameable-types = "warn"
 unsafe_code = "warn"
+unused_crate_dependencies = "warn"
+unused-import-braces = "warn"
+unused-lifetimes = "warn"
+unused-qualifications = "warn"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ blake2 = "0.10.6"
 rand_core = "0.6.4"
 
 [dev-dependencies]
-rand = "0.8.5"
 rand_chacha = "0.3.1"
 
 [lints.rust]

--- a/src/centralized_telescope.rs
+++ b/src/centralized_telescope.rs
@@ -12,7 +12,7 @@ type Element = [u8; DATA_LENGTH];
 type Hash = [u8; DIGEST_SIZE];
 
 /// Setup input parameters
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Params {
     /// Soundness security parameter
     pub lambda_sec: f64,
@@ -25,7 +25,7 @@ pub struct Params {
 }
 
 /// Setup output parameters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Setup {
     /// Approximate size of set Sp to lower bound
     pub n_p: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,6 @@ mod test_utils;
 mod utils;
 
 pub mod centralized_telescope;
+
+// Silence a rustc warning about unused crate.
+use rand_core as _;


### PR DESCRIPTION
This enables additional rustc lints. Their description can be found here: https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html.