### PR TITLE
Updating variable names

### DIFF
--- a/src/centralized_telescope/algorithm.rs
+++ b/src/centralized_telescope/algorithm.rs
@@ -9,26 +9,38 @@ use crate::utils::types::Element;
 use blake2::{Blake2s256, Digest};
 
 /// Alba's proving algorithm, based on a depth-first search algorithm.
-/// Calls up to setup.r times the prove_index function and returns an empty
+/// Calls up to setup.max_retries times the prove_index function and returns an empty
 /// proof if no suitable candidate is found.
-pub fn prove(setup: &Setup, set: &[Element]) -> Option<Proof> {
-    (0..setup.r).find_map(|v| prove_index(setup, set, v).1)
+pub fn prove(setup: &Setup, prover_set: &[Element]) -> Option<Proof> {
+    // Run prove_index up to max_retries times
+    (0..setup.max_retries).find_map(|retry_counter| prove_index(setup, prover_set, retry_counter).1)
 }
 
 /// Alba's verification algorithm, returns true if the proof is
 /// successfully verified, following the DFS verification, false otherwise.
 pub fn verify(setup: &Setup, proof: &Proof) -> bool {
-    if proof.t >= setup.d || proof.v >= setup.r || proof.items.len() as u64 != setup.u {
+    if proof.search_counter >= setup.search_width
+        || proof.retry_counter >= setup.max_retries
+        || proof.element_sequence.len() as u64 != setup.proof_size
+    {
         return false;
     }
-    let Some(mut round) = Round::new(proof.v, proof.t, setup.n_p) else {
+
+    // Initialise a round with given retry and search counters
+    let Some(mut round) = Round::new(proof.retry_counter, proof.search_counter, setup.set_size)
+    else {
         return false;
     };
-    for &element in &proof.items {
-        let Some(h) = h0(setup, proof.v, element) else {
+
+    // For each element in the proof's sequence
+    for &element in &proof.element_sequence {
+        // Retrieve the bin id associated to this new element
+        let Some(bin_id) = bin_hash(setup, proof.retry_counter, element) else {
             return false;
         };
-        if round.h_u64 == h {
+        // Check that the new element was chosen correctly
+        // i.e. that we chose the new element such that its bin id equals the round id
+        if round.id == bin_id {
             match Round::update(&round, element) {
                 Some(r) => round = r,
                 None => return false,
@@ -37,101 +49,115 @@ pub fn verify(setup: &Setup, proof: &Proof) -> bool {
             return false;
         }
     }
-    h2(setup, &round)
+    leaf_hash(setup, &round)
 }
 
 /// Indexed proving algorithm, returns the total number of DFS calls done
-/// to find a proof and Some(proof) if found within setup.b calls of DFS,
+/// to find a proof and Some(proof) if found within setup.dfs_bound calls of DFS,
 /// otherwise None
-fn prove_index(setup: &Setup, set: &[Element], v: u64) -> (u64, Option<Proof>) {
-    let mut bins: Vec<Vec<Element>> = Vec::with_capacity(setup.n_p as usize);
-    for _ in 0..setup.n_p {
+fn prove_index(setup: &Setup, prover_set: &[Element], retry_counter: u64) -> (u64, Option<Proof>) {
+    // Initialise set_size bins
+    let mut bins: Vec<Vec<Element>> = Vec::with_capacity(setup.set_size as usize);
+    for _ in 0..setup.set_size {
         bins.push(Vec::new());
     }
-    // Take only up to 2*np elements for efficiency
-    for &s in set.iter().take(setup.n_p.saturating_mul(2) as usize) {
-        match h0(setup, v, s) {
-            Some(h) => {
-                bins[h as usize].push(s);
+
+    // Take only up to 2*set_size elements for efficiency and fill the bins with them
+    for &element in prover_set
+        .iter()
+        .take(setup.set_size.saturating_mul(2) as usize)
+    {
+        match bin_hash(setup, retry_counter, element) {
+            Some(bin_index) => {
+                bins[bin_index as usize].push(element);
             }
             None => return (0, None),
         }
     }
 
-    let mut limit = 0;
-    for t in 0..setup.d {
-        if limit == setup.b {
-            return (limit, None);
+    // Run the DFS algorithm on up to search_width different trees
+    let mut step = 0;
+    for search_counter in 0..setup.search_width {
+        // If DFS was called more than dfs_bound times, abort this retry
+        if step >= setup.dfs_bound {
+            return (step, None);
         }
-        if let Some(r) = Round::new(v, t, setup.n_p) {
-            let (l, proof_opt) = dfs(setup, &bins, &r, limit.saturating_add(1));
+        // Initialise new round
+        if let Some(r) = Round::new(retry_counter, search_counter, setup.set_size) {
+            // Run DFS on such round, incrementing step
+            let (dfs_calls, proof_opt) = dfs(setup, &bins, &r, step.saturating_add(1));
+            // Returns proof if found
             if proof_opt.is_some() {
-                return (l, proof_opt);
+                return (dfs_calls, proof_opt);
             }
-            limit = l;
+            // Update step, that is the number of DFS calls
+            step = dfs_calls;
         }
     }
-    (limit, None)
+    (step, None)
 }
 
 /// Depth-First Search which goes through all potential round candidates
 /// and returns the total number of recursive DFS calls done and, if not
-/// found under setup.b calls, returns None otherwise Some(Proof), that is
-/// the first round candidate Round{v, t, x_1, ..., x_u)} such that:
-/// - ∀i ∈ [0, u-1], H0(x_i+1) ∈ bins[H1(...H1(H1(v, t), x_1), ..., x_i)]
-/// - H2(H1(... H1((H1(v, t), x_1), ..., x_u)) = true
-fn dfs(
-    setup: &Setup,
-    bins: &[Vec<Element>],
-    round: &Round,
-    mut limit: u64,
-) -> (u64, Option<Proof>) {
-    if round.s_list.len() as u64 == setup.u {
-        let proof_opt = if h2(setup, round) {
+/// found under setup.dfs_bound calls, returns None otherwise Some(Proof),
+/// that is the first round candidate Round{retry_counter, search_counter, x_1, ..., x_u)} such that:
+/// - ∀i ∈ [0, u-1], bin_hash(x_i+1) ∈ bins[node_hash(...node_hash(node_hash(v, t), x_1), ..., x_i)]
+/// - leaf_hash(node_hash(... node_hash((node_hash(v, t), x_1), ..., x_u)) = true
+fn dfs(setup: &Setup, bins: &[Vec<Element>], round: &Round, mut step: u64) -> (u64, Option<Proof>) {
+    // If current round comprises proof_size elements, returns it as Proof
+    if round.element_sequence.len() as u64 == setup.proof_size {
+        let proof_opt = if leaf_hash(setup, round) {
             Some(Proof {
-                v: round.v,
-                t: round.t,
-                items: round.s_list.clone(),
+                retry_counter: round.retry_counter,
+                search_counter: round.search_counter,
+                element_sequence: round.element_sequence.clone(),
             })
         } else {
             None
         };
-        return (limit, proof_opt);
+        return (step, proof_opt);
     }
 
-    for &s in &bins[round.h_u64 as usize] {
-        if limit == setup.b {
-            return (limit, None);
+    // For each element in bin numbered id
+    for &element in &bins[round.id as usize] {
+        // If DFS was called more than dfs_bound times, abort this round
+        if step == setup.dfs_bound {
+            return (step, None);
         }
-        if let Some(r) = Round::update(round, s) {
-            let (l, proof_opt) = dfs(setup, bins, &r, limit.saturating_add(1));
+        // Update round with such element
+        if let Some(r) = Round::update(round, element) {
+            // Run DFS on updated round, incrementing step
+            let (dfs_calls, proof_opt) = dfs(setup, bins, &r, step.saturating_add(1));
+            // Returns proof if found
             if proof_opt.is_some() {
-                return (l, proof_opt);
+                return (dfs_calls, proof_opt);
             }
-            limit = l;
+            // Update step, that is the number of DFS calls
+            step = dfs_calls;
         }
     }
-    (limit, None)
+    // If no proof was found, return number of steps and None
+    (step, None)
 }
 
-/// Oracle producing a uniformly random value in [0, n_p[ used for prehashing S_p
-fn h0(setup: &Setup, v: u64, s: Element) -> Option<u64> {
-    let v_bytes: [u8; 8] = v.to_be_bytes();
+/// Oracle producing a uniformly random value in [0, set_size[ used for prehashing S_p
+fn bin_hash(setup: &Setup, retry_counter: u64, element: Element) -> Option<u64> {
+    let retry_bytes: [u8; 8] = retry_counter.to_be_bytes();
     let mut hasher = Blake2s256::new();
-    hasher.update(b"Telescope-H0");
-    hasher.update(v_bytes);
-    hasher.update(s);
+    hasher.update(b"Telescope-bin_hash");
+    hasher.update(retry_bytes);
+    hasher.update(element);
     let digest: Hash = hasher.finalize().into();
-    sample::sample_uniform(&digest, setup.n_p)
+    sample::sample_uniform(&digest, setup.set_size)
 }
 
 /// Oracle defined as Bernoulli(q) returning 1 with probability q and 0 otherwise
-fn h2(setup: &Setup, r: &Round) -> bool {
+fn leaf_hash(setup: &Setup, r: &Round) -> bool {
     let mut hasher = Blake2s256::new();
-    hasher.update(b"Telescope-H2");
-    hasher.update(r.h);
+    hasher.update(b"Telescope-leaf_hash");
+    hasher.update(r.hash);
     let digest: Hash = hasher.finalize().into();
-    sample::sample_bernoulli(&digest, setup.q)
+    sample::sample_bernoulli(&digest, setup.leaf_probability)
 }
 
 #[cfg(test)]
@@ -149,10 +175,10 @@ mod tests {
         let nb_tests = 1_000;
         let set_size = 1_000;
         let params = Params {
-            lambda_sec: 10.0,
-            lambda_rel: 10.0,
-            n_p: 80 * set_size / 100,
-            n_f: 20 * set_size / 100,
+            soundness_param: 10.0,
+            completeness_param: 10.0,
+            set_size: 80 * set_size / 100,
+            lower_bound: 20 * set_size / 100,
         };
         for _t in 0..nb_tests {
             let seed = rng.next_u32().to_be_bytes().to_vec();
@@ -160,47 +186,47 @@ mod tests {
             let setup = init::make_setup(&params);
             let proof = prove(&setup, &s_p).unwrap();
             assert!(verify(&setup, &proof.clone()));
-            // Checking that the proof fails if proof.t is erroneous
+            // Checking that the proof fails if proof.search_counter is erroneous
             let proof_t = Proof {
-                v: proof.v,
-                t: proof.t.wrapping_add(1),
-                items: proof.items.clone(),
+                retry_counter: proof.retry_counter,
+                search_counter: proof.search_counter.wrapping_add(1),
+                element_sequence: proof.element_sequence.clone(),
             };
             assert!(!verify(&setup, &proof_t));
-            // Checking that the proof fails if proof.v is erroneous
+            // Checking that the proof fails if proof.retry_counter is erroneous
             let proof_v = Proof {
-                v: proof.v.wrapping_add(1),
-                t: proof.t,
-                items: proof.items.clone(),
+                retry_counter: proof.retry_counter.wrapping_add(1),
+                search_counter: proof.search_counter,
+                element_sequence: proof.element_sequence.clone(),
             };
             assert!(!verify(&setup, &proof_v));
             // Checking that the proof fails when no elements are included
             let proof_item = Proof {
-                v: proof.v,
-                t: proof.t,
-                items: Vec::new(),
+                retry_counter: proof.retry_counter,
+                search_counter: proof.search_counter,
+                element_sequence: Vec::new(),
             };
             assert!(!verify(&setup, &proof_item));
             // Checking that the proof fails when wrong elements are included
-            // We are trying to trigger H2
-            let mut wrong_items = proof.items.clone();
+            // We are trying to trigger leaf_hash
+            let mut wrong_items = proof.element_sequence.clone();
             let last_item = wrong_items.pop().unwrap();
             let mut penultimate_item = wrong_items.pop().unwrap();
             let proof_itembis = Proof {
-                v: proof.v,
-                t: proof.t,
-                items: wrong_items.clone(),
+                retry_counter: proof.retry_counter,
+                search_counter: proof.search_counter,
+                element_sequence: wrong_items.clone(),
             };
             assert!(!verify(&setup, &proof_itembis));
             // Checking that the proof fails when wrong elements are included
-            // We are trying to trigger H1
+            // We are trying to trigger node_hash
             penultimate_item[0] = penultimate_item[0].wrapping_add(42u8);
             wrong_items.push(penultimate_item);
             wrong_items.push(last_item);
             let proof_itembis = Proof {
-                v: proof.v,
-                t: proof.t,
-                items: wrong_items.clone(),
+                retry_counter: proof.retry_counter,
+                search_counter: proof.search_counter,
+                element_sequence: wrong_items.clone(),
             };
             assert!(!verify(&setup, &proof_itembis));
         }

--- a/src/centralized_telescope/algorithm.rs
+++ b/src/centralized_telescope/algorithm.rs
@@ -157,7 +157,7 @@ fn leaf_hash(setup: &Setup, r: &Round) -> bool {
     hasher.update(b"Telescope-leaf_hash");
     hasher.update(r.hash);
     let digest: Hash = hasher.finalize().into();
-    sample::sample_bernoulli(&digest, setup.leaf_probability)
+    sample::sample_bernoulli(&digest, setup.valid_proof_probability)
 }
 
 #[cfg(test)]

--- a/src/centralized_telescope/init.rs
+++ b/src/centralized_telescope/init.rs
@@ -7,69 +7,75 @@ use std::f64::consts::LOG2_E;
 
 /// Setup algorithm taking a Params as input and returning setup parameters (u,d,q)
 pub fn make_setup(params: &Params) -> Setup {
-    let n_p_f64 = params.n_p as f64;
-    let n_f_f64 = params.n_f as f64;
+    let set_size_f64 = params.set_size as f64;
+    let lower_bound_f64 = params.lower_bound as f64;
 
-    let u_f64 = {
-        let numerator = params.lambda_sec + params.lambda_rel.log2() + 5.0 - LOG2_E.log2();
-        let denominator = (n_p_f64 / n_f_f64).log2();
+    let proof_size_f64 = {
+        let numerator =
+            params.soundness_param + params.completeness_param.log2() + 5.0 - LOG2_E.log2();
+        let denominator = (set_size_f64 / lower_bound_f64).log2();
         (numerator / denominator).ceil()
     };
 
-    let ratio = 9.0 * n_p_f64 * LOG2_E / ((17.0 * u_f64).powi(2));
+    let ratio = 9.0 * set_size_f64 * LOG2_E / ((17.0 * proof_size_f64).powi(2));
     let s1 = ratio - 7.0;
     let s2 = ratio - 2.0;
 
     if s1 < 1.0 || s2 < 1.0 {
-        // Small case, i.e. n_p <= λ^2
-        param_small_case(params, u_f64)
+        // Small case, i.e. set_size <= λ^2
+        param_small_case(params, proof_size_f64)
     } else {
-        let lambda_rel2 = params.lambda_rel.min(s2);
-        if u_f64 < lambda_rel2 {
-            // Case 3, Theorem 14, i.e.  n_p >= λ^3
-            param_high_case(params, u_f64, lambda_rel2)
+        let completeness_param2 = params.completeness_param.min(s2);
+        if proof_size_f64 < completeness_param2 {
+            // Case 3, Theorem 14, i.e.  set_size >= λ^3
+            param_high_case(params, proof_size_f64, completeness_param2)
         } else {
-            // Case 2, Theorem 13, i.e. λ^3 > n_p > λ^2
-            param_mid_case(params, u_f64, s1)
+            // Case 2, Theorem 13, i.e. λ^3 > set_size > λ^2
+            param_mid_case(params, proof_size_f64, s1)
         }
     }
 }
 
-fn param_small_case(params: &Params, u_f64: f64) -> Setup {
+fn param_small_case(params: &Params, proof_size_f64: f64) -> Setup {
     let ln12 = (12f64).ln();
-    let d = (32.0 * ln12 * u_f64).ceil();
+    let search_width = (32.0 * ln12 * proof_size_f64).ceil();
     Setup {
-        n_p: params.n_p,
-        u: u_f64 as u64,
-        r: params.lambda_rel as u64,
-        d: d as u64,
-        q: 2.0 * ln12 / d,
-        b: (8.0 * (u_f64 + 1.0) * d / ln12).floor() as u64,
+        set_size: params.set_size,
+        proof_size: proof_size_f64 as u64,
+        max_retries: params.completeness_param as u64,
+        search_width: search_width as u64,
+        leaf_probability: 2.0 * ln12 / search_width,
+        dfs_bound: (8.0 * (proof_size_f64 + 1.0) * search_width / ln12).floor() as u64,
     }
 }
 
-fn param_high_case(params: &Params, u_f64: f64, lambda_rel2: f64) -> Setup {
-    let l2 = lambda_rel2 + 2.0;
-    let d = (16.0 * u_f64 * l2 / LOG2_E).ceil();
-    debug_assert!(params.n_p as f64 >= d * d * LOG2_E / (9.0 * l2));
+fn param_high_case(params: &Params, proof_size_f64: f64, completeness_param2: f64) -> Setup {
+    let l2 = completeness_param2 + 2.0;
+    let search_width = (16.0 * proof_size_f64 * l2 / LOG2_E).ceil();
+    debug_assert!(params.set_size as f64 >= search_width * search_width * LOG2_E / (9.0 * l2));
     Setup {
-        n_p: params.n_p,
-        u: u_f64 as u64,
-        r: (params.lambda_rel / lambda_rel2).ceil() as u64,
-        d: d as u64,
-        q: 2.0 * l2 / (d * LOG2_E),
-        b: (((l2 + u_f64.log2()) / l2) * (3.0 * u_f64 * d / 4.0) + d + u_f64).floor() as u64,
+        set_size: params.set_size,
+        proof_size: proof_size_f64 as u64,
+        max_retries: (params.completeness_param / completeness_param2).ceil() as u64,
+        search_width: search_width as u64,
+        leaf_probability: 2.0 * l2 / (search_width * LOG2_E),
+        dfs_bound: (((l2 + proof_size_f64.log2()) / l2)
+            * (3.0 * proof_size_f64 * search_width / 4.0)
+            + search_width
+            + proof_size_f64)
+            .floor() as u64,
     }
 }
 
-fn param_mid_case(params: &Params, u_f64: f64, s1: f64) -> Setup {
-    fn compute_w(u: f64, l: f64) -> f64 {
-        fn factorial_check(w: f64, l: f64) -> bool {
-            let bound = (-l).exp2();
-            let mut factor = (w.ceil() as u64).saturating_add(1);
-            let w_2 = w + 2.0;
-            let exp_1_over_w = w.recip().exp();
-            let mut ratio = (14.0 * w * w * w_2 * exp_1_over_w) / (w_2 - exp_1_over_w);
+fn param_mid_case(params: &Params, proof_size_f64: f64, s1: f64) -> Setup {
+    fn max_vertices_visited(proof_size: f64, l1: f64) -> f64 {
+        fn factorial_check(max_v: f64, l1: f64) -> bool {
+            let bound = (-l1).exp2();
+            let mut factor = (max_v.ceil() as u64).saturating_add(1);
+            let max_v_2 = max_v + 2.0;
+            let exp_1_over_max_v = max_v.recip().exp();
+            let mut ratio =
+                (14.0 * max_v * max_v * max_v_2 * exp_1_over_max_v) / (max_v_2 - exp_1_over_max_v);
             while factor != 0 {
                 ratio /= factor as f64;
                 if ratio <= bound {
@@ -79,26 +85,30 @@ fn param_mid_case(params: &Params, u_f64: f64, s1: f64) -> Setup {
             }
             false
         }
-        let mut w = u;
-        while !factorial_check(w, l) {
-            w += 1.0;
+        let mut max_v = proof_size;
+        while !factorial_check(max_v, l1) {
+            max_v += 1.0;
         }
-        w
+        max_v
     }
-    let lambda_rel1 = params.lambda_rel.min(s1);
-    let lbar = (lambda_rel1 + 7.0) / LOG2_E;
-    let d = (16.0 * u_f64 * lbar).ceil();
-    let lbar_over_d = lbar / d;
-    debug_assert!(params.n_p as f64 >= d * d / (9.0 * lbar));
+    let completeness_param1 = params.completeness_param.min(s1);
+    let lbar = (completeness_param1 + 7.0) / LOG2_E;
+    let search_width = (16.0 * proof_size_f64 * lbar).ceil();
+    let lbar_over_sw = lbar / search_width;
+    debug_assert!(params.set_size as f64 >= search_width * search_width / (9.0 * lbar));
 
-    let w = compute_w(u_f64, lambda_rel1);
-    let exponential = (2.0 * u_f64 * w * lbar / params.n_p as f64 + 7.0 * u_f64 / w).exp();
+    let max_v = max_vertices_visited(proof_size_f64, completeness_param1);
+    let exponential = (2.0 * proof_size_f64 * max_v * lbar / params.set_size as f64
+        + 7.0 * proof_size_f64 / max_v)
+        .exp();
     Setup {
-        n_p: params.n_p,
-        u: u_f64 as u64,
-        r: (params.lambda_rel / lambda_rel1).ceil() as u64,
-        d: d as u64,
-        q: 2.0 * lbar_over_d,
-        b: ((w * lbar_over_d + 1.0) * exponential * d * u_f64 + d).floor() as u64,
+        set_size: params.set_size,
+        proof_size: proof_size_f64 as u64,
+        max_retries: (params.completeness_param / completeness_param1).ceil() as u64,
+        search_width: search_width as u64,
+        leaf_probability: 2.0 * lbar_over_sw,
+        dfs_bound: ((max_v * lbar_over_sw + 1.0) * exponential * search_width * proof_size_f64
+            + search_width)
+            .floor() as u64,
     }
 }

--- a/src/centralized_telescope/init.rs
+++ b/src/centralized_telescope/init.rs
@@ -44,7 +44,7 @@ fn param_small_case(params: &Params, proof_size_f64: f64) -> Setup {
         proof_size: proof_size_f64 as u64,
         max_retries: params.completeness_param as u64,
         search_width: search_width as u64,
-        leaf_probability: 2.0 * ln12 / search_width,
+        valid_proof_probability: 2.0 * ln12 / search_width,
         dfs_bound: (8.0 * (proof_size_f64 + 1.0) * search_width / ln12).floor() as u64,
     }
 }
@@ -58,7 +58,7 @@ fn param_high_case(params: &Params, proof_size_f64: f64, completeness_param2: f6
         proof_size: proof_size_f64 as u64,
         max_retries: (params.completeness_param / completeness_param2).ceil() as u64,
         search_width: search_width as u64,
-        leaf_probability: 2.0 * l2 / (search_width * LOG2_E),
+        valid_proof_probability: 2.0 * l2 / (search_width * LOG2_E),
         dfs_bound: (((l2 + proof_size_f64.log2()) / l2)
             * (3.0 * proof_size_f64 * search_width / 4.0)
             + search_width
@@ -106,7 +106,7 @@ fn param_mid_case(params: &Params, proof_size_f64: f64, s1: f64) -> Setup {
         proof_size: proof_size_f64 as u64,
         max_retries: (params.completeness_param / completeness_param1).ceil() as u64,
         search_width: search_width as u64,
-        leaf_probability: 2.0 * lbar_over_sw,
+        valid_proof_probability: 2.0 * lbar_over_sw,
         dfs_bound: ((max_v * lbar_over_sw + 1.0) * exponential * search_width * proof_size_f64
             + search_width)
             .floor() as u64,

--- a/src/centralized_telescope/init.rs
+++ b/src/centralized_telescope/init.rs
@@ -30,12 +30,13 @@ pub fn make_setup(params: &Params) -> Setup {
             // Case 3, Theorem 14, i.e.  set_size >= λ^3
             param_high_case(params, proof_size_f64, completeness_param2)
         } else {
-            // Case 2, Theorem 13, i.e. λ^3 > set_size > λ^2
+            // Case 2, Theorem 13, i.e. λ^2 < set_size < λ^3
             param_mid_case(params, proof_size_f64, s1)
         }
     }
 }
 
+/// Helper function that returns Setup, used when set_size <= λ^2
 fn param_small_case(params: &Params, proof_size_f64: f64) -> Setup {
     let ln12 = (12f64).ln();
     let search_width = (32.0 * ln12 * proof_size_f64).ceil();
@@ -49,6 +50,7 @@ fn param_small_case(params: &Params, proof_size_f64: f64) -> Setup {
     }
 }
 
+/// Helper function that returns Setup, used when set_size >= λ^3
 fn param_high_case(params: &Params, proof_size_f64: f64, completeness_param2: f64) -> Setup {
     let l2 = completeness_param2 + 2.0;
     let search_width = (16.0 * proof_size_f64 * l2 / LOG2_E).ceil();
@@ -67,6 +69,7 @@ fn param_high_case(params: &Params, proof_size_f64: f64, completeness_param2: f6
     }
 }
 
+/// Helper function that returns Setup, used when λ^2 < set_size < λ^3
 fn param_mid_case(params: &Params, proof_size_f64: f64, s1: f64) -> Setup {
     fn max_vertices_visited(proof_size: f64, l1: f64) -> f64 {
         fn factorial_check(max_v: f64, l1: f64) -> bool {

--- a/src/centralized_telescope/params.rs
+++ b/src/centralized_telescope/params.rs
@@ -4,11 +4,11 @@
 #[derive(Debug, Clone, Copy)]
 pub struct Params {
     /// Soundness security parameter
-    pub lambda_sec: f64,
+    pub soundness_param: f64,
     /// Completeness security parameter
-    pub lambda_rel: f64,
-    /// Approximate size of set Sp to lower bound
-    pub n_p: u64,
-    /// Target lower bound
-    pub n_f: u64,
+    pub completeness_param: f64,
+    /// Approximate size of the prover set to lower bound
+    pub set_size: u64,
+    /// Lower bound to prove on prover set
+    pub lower_bound: u64,
 }

--- a/src/centralized_telescope/proof.rs
+++ b/src/centralized_telescope/proof.rs
@@ -5,10 +5,10 @@ use crate::utils::types::Element;
 /// Alba proof
 #[derive(Debug, Clone)]
 pub struct Proof {
-    /// Proof counter
-    pub v: u64,
-    /// Proof 2nd counter
-    pub t: u64,
-    /// Proof tuple
-    pub items: Vec<Element>,
+    /// Numbers of retries done to find the proof
+    pub retry_counter: u64,
+    /// Index of the searched subtree to find the proof
+    pub search_counter: u64,
+    /// Sequence of elements from prover set
+    pub element_sequence: Vec<Element>,
 }

--- a/src/centralized_telescope/round.rs
+++ b/src/centralized_telescope/round.rs
@@ -24,12 +24,12 @@ pub struct Round {
 
 impl Round {
     /// Output a round from retry and search counters as well as set_size
-    /// Initilialises the hash with node_hash(retry_counter || search_bytes)
-    /// and random value as oracle(node_hash(retry_counter || search_bytes), set_size)
+    /// Initilialises the hash with round_hash(retry_counter || search_bytes)
+    /// and random value as oracle(round_hash(retry_counter || search_bytes), set_size)
     pub(super) fn new(retry_counter: u64, search_counter: u64, set_size: u64) -> Option<Self> {
         let retry_bytes: [u8; 8] = retry_counter.to_be_bytes();
         let search_bytes: [u8; 8] = search_counter.to_be_bytes();
-        let (hash, id_opt) = Self::node_hash(&retry_bytes, &search_bytes, set_size);
+        let (hash, id_opt) = Self::round_hash(&retry_bytes, &search_bytes, set_size);
         id_opt.map(|id| Self {
             retry_counter,
             search_counter,
@@ -41,11 +41,11 @@ impl Round {
     }
 
     /// Updates a round with an element
-    /// Replaces the hash $h$ with $h' = node_hash(h, s)$ and the random value as oracle(h', set_size)
+    /// Replaces the hash $h$ with $h' = round_hash(h, s)$ and the random value as oracle(h', set_size)
     pub(super) fn update(r: &Self, element: Element) -> Option<Self> {
         let mut element_sequence = r.element_sequence.clone();
         element_sequence.push(element);
-        let (hash, id_opt) = Self::node_hash(&r.hash, &element, r.set_size);
+        let (hash, id_opt) = Self::round_hash(&r.hash, &element, r.set_size);
         id_opt.map(|id| Self {
             retry_counter: r.retry_counter,
             search_counter: r.search_counter,
@@ -58,9 +58,9 @@ impl Round {
 
     /// Oracle producing a uniformly random value in [0, set_size[ used for round candidates
     /// We also return hash(data) to follow the optimization presented in Section 3.3
-    fn node_hash(first_input: &[u8], second_input: &[u8], set_size: u64) -> (Hash, Option<u64>) {
+    fn round_hash(first_input: &[u8], second_input: &[u8], set_size: u64) -> (Hash, Option<u64>) {
         let mut hasher = Blake2s256::new();
-        hasher.update(b"Telescope-node_hash");
+        hasher.update(b"Telescope-round_hash");
         hasher.update(first_input);
         hasher.update(second_input);
         let digest: Hash = hasher.finalize().into();

--- a/src/centralized_telescope/setup.rs
+++ b/src/centralized_telescope/setup.rs
@@ -3,7 +3,7 @@
 /// Setup output parameters
 #[derive(Debug, Clone, Copy)]
 pub struct Setup {
-    /// Approximate size of prover set to lower bound
+    /// Total number of elements available to the prover
     pub set_size: u64,
     /// Number of prover set's elements
     pub proof_size: u64,

--- a/src/centralized_telescope/setup.rs
+++ b/src/centralized_telescope/setup.rs
@@ -3,16 +3,16 @@
 /// Setup output parameters
 #[derive(Debug, Clone, Copy)]
 pub struct Setup {
-    /// Approximate size of set Sp to lower bound
-    pub n_p: u64,
-    /// Proof size (in Sp elements)
-    pub u: u64,
-    /// Proof max counter
-    pub r: u64,
-    /// Proof max 2nd counter
-    pub d: u64,
-    /// Probability q
-    pub q: f64,
-    /// Computation bound
-    pub b: u64,
+    /// Approximate size of prover set to lower bound
+    pub set_size: u64,
+    /// Number of prover set's elements
+    pub proof_size: u64,
+    /// Maximum number of retries to find a proof
+    pub max_retries: u64,
+    /// Maximum number of subtrees to search to find a proof
+    pub search_width: u64,
+    /// Probability that a leaf was correctly chosen
+    pub leaf_probability: f64,
+    /// Maximum number of DFS calls permitted to find a proof
+    pub dfs_bound: u64,
 }

--- a/src/centralized_telescope/setup.rs
+++ b/src/centralized_telescope/setup.rs
@@ -11,8 +11,8 @@ pub struct Setup {
     pub max_retries: u64,
     /// Maximum number of subtrees to search to find a proof
     pub search_width: u64,
-    /// Probability that a leaf was correctly chosen
-    pub leaf_probability: f64,
+    /// Probability that a tuple of element is a valid proof
+    pub valid_proof_probability: f64,
     /// Maximum number of DFS calls permitted to find a proof
     pub dfs_bound: u64,
 }

--- a/src/simple_lottery/setup.rs
+++ b/src/simple_lottery/setup.rs
@@ -3,8 +3,8 @@
 /// Setup output parameters
 #[derive(Debug, Clone, Copy)]
 pub struct Setup {
-    /// Proof size (in Sp elements)
-    pub u: u64,
-    /// Lottery oracle probability
-    pub p: f64,
+    /// Number of prover set's elements
+    pub proof_size: u64,
+    /// Probability of winning the lottery, i.e. that one's element will be aggregated
+    pub lottery_probability: f64,
 }

--- a/src/utils/sample.rs
+++ b/src/utils/sample.rs
@@ -7,7 +7,7 @@ use std::cmp::min;
 pub(crate) fn sample_uniform(hash: &[u8], n: u64) -> Option<u64> {
     // Computes the integer reprensation of hash* modulo n when n is not a
     // power of two. *(up to 8 bytes, in little endian)
-    fn mod_noset_sizeower_of_2(hash: &[u8], n: u64) -> Option<u64> {
+    fn mod_not_power_of_2(hash: &[u8], n: u64) -> Option<u64> {
         fn log_base2(x: u64) -> u64 {
             u64::from(
                 u64::BITS
@@ -15,12 +15,11 @@ pub(crate) fn sample_uniform(hash: &[u8], n: u64) -> Option<u64> {
                     .saturating_sub(1),
             )
         }
-        let epsilolower_boundail: u64 = 1 << 40; // TODO: update
-        let k = log_base2(n.saturating_mul(epsilolower_boundail));
-        let k_prime: u64 = 1 << k;
-        let d = k_prime.div_ceil(n);
-
-        let i = mod_power_of_2(hash, k_prime);
+        let epsilon_fail: u64 = 1 << 40; // TODO: update
+        let k = log_base2(n.saturating_mul(epsilon_fail));
+        let new_n: u64 = 1 << k;
+        let d = new_n.div_ceil(n);
+        let i = mod_power_of_2(hash, new_n);
 
         if i >= d.saturating_mul(n) {
             None
@@ -38,7 +37,7 @@ pub(crate) fn sample_uniform(hash: &[u8], n: u64) -> Option<u64> {
     if n.is_power_of_two() {
         Some(mod_power_of_2(hash, n))
     } else {
-        mod_noset_sizeower_of_2(hash, n)
+        mod_not_power_of_2(hash, n)
     }
 }
 
@@ -48,12 +47,12 @@ pub(crate) fn sample_uniform(hash: &[u8], n: u64) -> Option<u64> {
 pub(crate) fn sample_bernoulli(hash: &[u8], q: f64) -> bool {
     // For error parameter ɛ̝, find an approximation x/y of q with (x,y) in N²
     // such that 0 < q - x/y <= ɛ̝
-    let epsilolower_boundail: u64 = 1 << 40; // TOOD: update
+    let epsilon_fail: u64 = 1 << 40; // TOOD: update
     let mut x: u64 = q.ceil() as u64;
     let mut y: u64 = 1;
     while {
         let difference = q - (x as f64 / y as f64);
-        difference >= 1.0 / epsilolower_boundail as f64 || difference < 0.0
+        difference >= 1.0 / epsilon_fail as f64 || difference < 0.0
     } {
         y = y.saturating_mul(2);
         x = (q * (y as f64)).round() as u64;

--- a/src/utils/sample.rs
+++ b/src/utils/sample.rs
@@ -7,7 +7,7 @@ use std::cmp::min;
 pub(crate) fn sample_uniform(hash: &[u8], n: u64) -> Option<u64> {
     // Computes the integer reprensation of hash* modulo n when n is not a
     // power of two. *(up to 8 bytes, in little endian)
-    fn mod_non_power_of_2(hash: &[u8], n: u64) -> Option<u64> {
+    fn mod_noset_sizeower_of_2(hash: &[u8], n: u64) -> Option<u64> {
         fn log_base2(x: u64) -> u64 {
             u64::from(
                 u64::BITS
@@ -15,8 +15,8 @@ pub(crate) fn sample_uniform(hash: &[u8], n: u64) -> Option<u64> {
                     .saturating_sub(1),
             )
         }
-        let epsilon_fail: u64 = 1 << 40; // TODO: update
-        let k = log_base2(n.saturating_mul(epsilon_fail));
+        let epsilolower_boundail: u64 = 1 << 40; // TODO: update
+        let k = log_base2(n.saturating_mul(epsilolower_boundail));
         let k_prime: u64 = 1 << k;
         let d = k_prime.div_ceil(n);
 
@@ -38,22 +38,22 @@ pub(crate) fn sample_uniform(hash: &[u8], n: u64) -> Option<u64> {
     if n.is_power_of_two() {
         Some(mod_power_of_2(hash, n))
     } else {
-        mod_non_power_of_2(hash, n)
+        mod_noset_sizeower_of_2(hash, n)
     }
 }
 
-/// Takes as input a hash and probability $q$ and returns true with
+/// Takes as input a hash and probability q and returns true with
 /// probability q otherwise false according to a Bernoulli distribution
 /// (c.f. Appendix B, Alba paper).
 pub(crate) fn sample_bernoulli(hash: &[u8], q: f64) -> bool {
     // For error parameter ɛ̝, find an approximation x/y of q with (x,y) in N²
     // such that 0 < q - x/y <= ɛ̝
-    let epsilon_fail: u64 = 1 << 40; // TOOD: update
+    let epsilolower_boundail: u64 = 1 << 40; // TOOD: update
     let mut x: u64 = q.ceil() as u64;
     let mut y: u64 = 1;
     while {
         let difference = q - (x as f64 / y as f64);
-        difference >= 1.0 / epsilon_fail as f64 || difference < 0.0
+        difference >= 1.0 / epsilolower_boundail as f64 || difference < 0.0
     } {
         y = y.saturating_mul(2);
         x = (q * (y as f64)).round() as u64;


### PR DESCRIPTION
## Content

Update variable names as discussed in https://github.com/cardano-scaling/alba/issues/38

## Comments

I changed `round_hash` (resp. `round_id`) to `hash` (resp. `id`) directly to dismiss clippy warnings.
As they are always used as `round.hash/id`, I thought this change was reasonable.

PR blocked by https://github.com/cardano-scaling/alba/pull/50
 
## Issue(s)

Relates to #38 