### PR TITLE
Move website deployment out of Rust CI

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,30 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: ✅ Checkout
+        uses: actions/checkout@v4
+
+      - name: 🪨 Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: '0.4.40'
+
+      - name: 📓 Build website
+        run: mdbook build website
+
+      - name: 🚀 Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/book
+          cname: alba.cardano-scaling.org

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -69,28 +69,3 @@ jobs:
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-
-
-  docs:
-    permissions:
-      contents: write
-
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: ✅ Checkout
-        uses: actions/checkout@v4
-
-      - name: 🪨 Setup mdBook
-        uses: peaceiris/actions-mdbook@v2
-        with:
-          mdbook-version: '0.4.40'
-
-      - name: 📓 Build website
-        run: mdbook build website
-
-      - name: 🚀 Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/book
-          cname: alba.cardano-scaling.org


### PR DESCRIPTION
## Content

The website stuff shouldn't be part of Rust CI. Also, the skipped docs check that never runs on pull requests is a bit annoying.

![Screenshot 2024-11-18 at 23-10-37 Design document by tolikzinovyev · Pull Request #67 · cardano-scaling_alba](https://github.com/user-attachments/assets/ce0626fe-385f-474a-838e-a76c4f754fe2)