### PR TITLE
Update `DATA_LENGTH`

### DIFF
--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,3 +1,3 @@
-pub(crate) const DATA_LENGTH: usize = 32;
+pub(crate) const DATA_LENGTH: usize = 48;
 
 pub(crate) type Element = [u8; DATA_LENGTH];

--- a/tests/centralized_telescope.rs
+++ b/tests/centralized_telescope.rs
@@ -10,7 +10,7 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 use utils::gen_items;
 
-const DATA_LENGTH: usize = 32;
+const DATA_LENGTH: usize = 48;
 
 fn test(created_with_params: bool) {
     let mut rng = ChaCha20Rng::from_seed(Default::default());


### PR DESCRIPTION
## Content
For the example of `centralized_telescope`, we will use bls signatures.
In order to use bls signatures as set elements, we need the data length to be 48 bytes. 

## Pre-submit checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
- PR
    - [ ] No clippy warnings in the CI
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

## Issue(s)
Closes #112 