### PR TITLE
Using generics inputs

### DIFF
--- a/benches/centralized_telescope/verifying_time.rs
+++ b/benches/centralized_telescope/verifying_time.rs
@@ -24,7 +24,8 @@ fn verify_duration(params: &BenchParam, truncate_size: u64, n: u64) -> Duration 
     // Truncate the dataset to give truncate_size elements to the prover
     dataset.truncate(truncate_size as usize);
     // Generate the proof
-    let proof_opt: Option<alba::centralized_telescope::proof::Proof> = telescope.prove(&dataset);
+    let proof_opt: Option<alba::centralized_telescope::proof::Proof<[u8; 48]>> =
+        telescope.prove(&dataset);
 
     if let Some(proof) = proof_opt {
         // Iterate on each sample `n` times

--- a/examples/aggregate_signature/helpers.rs
+++ b/examples/aggregate_signature/helpers.rs
@@ -1,6 +1,6 @@
 use crate::aggregate_signature::registration::Registration;
 use crate::aggregate_signature::signature::IndividualSignature;
-use crate::{AlbaThresholdSignature, Element};
+use crate::AlbaThresholdSignature;
 use blake2::digest::{Update, VariableOutput};
 use blake2::Blake2bVar;
 use blst::min_sig::{AggregatePublicKey, AggregateSignature, PublicKey, Signature};
@@ -26,7 +26,7 @@ pub(crate) fn collect_valid_signatures<const N: usize>(
     signature_list: &[IndividualSignature],
     registration: &Registration,
     msg: &[u8],
-) -> HashMap<Element, usize> {
+) -> HashMap<[u8; 48], usize> {
     let mut valid_signatures = HashMap::new();
 
     match &registration.checksum {

--- a/examples/centralized_threshold.rs
+++ b/examples/centralized_threshold.rs
@@ -12,13 +12,14 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 use std::time::Instant;
 mod aggregate_signature;
+
 const DATA_LENGTH: usize = 48;
-pub(crate) type Element = [u8; DATA_LENGTH];
+pub(crate) type Data = [u8; DATA_LENGTH];
 
 #[derive(Debug, Clone)]
 pub(crate) struct AlbaThresholdSignature {
     /// Centralized telescope proof
-    pub(crate) proof: Proof,
+    pub(crate) proof: Proof<Data>,
     /// Registration indices of the element sequence signers
     pub(crate) indices: Vec<usize>,
     /// Commitment `Hash(checksum || msg)`
@@ -57,7 +58,7 @@ impl AlbaThresholdSignature {
             }
 
             // Collect the byte representation of valid signatures into a Vec
-            let prover_set: Vec<Element> = valid_signatures.keys().copied().collect();
+            let prover_set: Vec<Data> = valid_signatures.keys().copied().collect();
 
             println!("-- Creating alba proof. ");
             let time_gen_proof = Instant::now();
@@ -83,7 +84,7 @@ impl AlbaThresholdSignature {
             let indices: Vec<usize> = proof
                 .element_sequence
                 .iter()
-                .filter_map(|element| valid_signatures.get(element.as_slice()).copied())
+                .filter_map(|element: &Data| valid_signatures.get(element.as_slice()).copied())
                 .collect();
 
             let commitment = get_commitment::<N>(checksum, msg).to_vec();

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -10,9 +10,6 @@ use blst::min_sig::PublicKey;
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 
-const DATA_LENGTH: usize = 48;
-type Element = [u8; DATA_LENGTH];
-
 fn main() {
     let mut rng = ChaCha20Rng::from_seed(Default::default());
     let mut msg = [0u8; 16];

--- a/examples/simple_threshold_signature/threshold_signature.rs
+++ b/examples/simple_threshold_signature/threshold_signature.rs
@@ -4,11 +4,11 @@ use alba::centralized_telescope::Telescope;
 use blst::min_sig::{PublicKey, Signature as BlsSignature};
 use blst::BLST_ERROR;
 
-const DATA_LENGTH: usize = 48;
-pub(crate) type Data = [u8; DATA_LENGTH];
+const SIG_LENGTH: usize = 48;
+pub(crate) type SigBytes = [u8; SIG_LENGTH];
 
 pub(crate) struct ThresholdSignature {
-    proof: Proof<Data>,
+    proof: Proof<SigBytes>,
 }
 
 impl ThresholdSignature {
@@ -21,7 +21,7 @@ impl ThresholdSignature {
         public_key_list: &[(usize, PublicKey)],
     ) -> (Self, Vec<usize>) {
         // Convert signatures to bytes and collect as the prover set.
-        let prover_set: Vec<Data> = signatures.iter().map(|s| s.signature.to_bytes()).collect();
+        let prover_set: Vec<SigBytes> = signatures.iter().map(|s| s.signature.to_bytes()).collect();
 
         println!("-- Creating alba proof. ");
         // Create alba proof with the prover set

--- a/examples/simple_threshold_signature/threshold_signature.rs
+++ b/examples/simple_threshold_signature/threshold_signature.rs
@@ -1,12 +1,14 @@
 use crate::simple_threshold_signature::signature::Signature;
-use crate::Element;
 use alba::centralized_telescope::proof::Proof;
 use alba::centralized_telescope::Telescope;
 use blst::min_sig::{PublicKey, Signature as BlsSignature};
 use blst::BLST_ERROR;
 
+const DATA_LENGTH: usize = 48;
+pub(crate) type Data = [u8; DATA_LENGTH];
+
 pub(crate) struct ThresholdSignature {
-    proof: Proof,
+    proof: Proof<Data>,
 }
 
 impl ThresholdSignature {
@@ -19,10 +21,7 @@ impl ThresholdSignature {
         public_key_list: &[(usize, PublicKey)],
     ) -> (Self, Vec<usize>) {
         // Convert signatures to bytes and collect as the prover set.
-        let prover_set = signatures
-            .iter()
-            .map(|s| s.signature.to_bytes())
-            .collect::<Vec<Element>>();
+        let prover_set: Vec<Data> = signatures.iter().map(|s| s.signature.to_bytes()).collect();
 
         println!("-- Creating alba proof. ");
         // Create alba proof with the prover set

--- a/src/centralized_telescope/proof.rs
+++ b/src/centralized_telescope/proof.rs
@@ -9,7 +9,7 @@ use blake2::{Blake2s256, Digest};
 
 /// Centralized Telescope proof
 #[derive(Debug, Clone)]
-pub struct Proof<E: AsRef<[u8]> + Clone + Ord> {
+pub struct Proof<E> {
     /// Numbers of retries done to find the proof
     pub retry_counter: u64,
     /// Index of the searched subtree to find the proof

--- a/src/centralized_telescope/proof.rs
+++ b/src/centralized_telescope/proof.rs
@@ -6,22 +6,22 @@ use super::params::Params;
 use super::round::Round;
 use crate::utils::{
     sample,
-    types::{Element, Hash},
+    types::{Hash, ToBytes},
 };
 use blake2::{Blake2s256, Digest};
 
 /// Centralized Telescope proof
 #[derive(Debug, Clone)]
-pub struct Proof {
+pub struct Proof<E: ToBytes + Clone + Sized + Ord> {
     /// Numbers of retries done to find the proof
     pub retry_counter: u64,
     /// Index of the searched subtree to find the proof
     pub search_counter: u64,
     /// Sequence of elements from prover's set
-    pub element_sequence: Vec<Element>,
+    pub element_sequence: Vec<E>,
 }
 
-impl Proof {
+impl<E: ToBytes + Clone + Sized + Ord> Proof<E> {
     /// Centralized Telescope's proving algorithm, based on a DFS algorithm.
     /// Calls up to `params.max_retries` times the prove_index function and
     /// returns a `Proof` if a suitable candidate tuple is found.
@@ -35,7 +35,7 @@ impl Proof {
     /// # Returns
     ///
     /// A `Proof` structure
-    pub(super) fn new(set_size: u64, params: &Params, prover_set: &[Element]) -> Option<Self> {
+    pub(super) fn new(set_size: u64, params: &Params, prover_set: &[E]) -> Option<Self> {
         debug_assert!(crate::utils::misc::check_distinct(prover_set));
 
         Self::prove_routine(set_size, params, prover_set).1
@@ -68,7 +68,7 @@ impl Proof {
     /// }
     /// let (setps, proof_opt) = Proof::bench(set_size, &params, &prover_set);
     /// ```
-    pub fn bench(set_size: u64, params: &Params, prover_set: &[Element]) -> (u64, Option<Proof>) {
+    pub fn bench(set_size: u64, params: &Params, prover_set: &[E]) -> (u64, Option<Self>) {
         Self::prove_routine(set_size, params, prover_set)
     }
 
@@ -76,11 +76,7 @@ impl Proof {
     /// Calls up to `params.max_retries` times the prove_index function and
     /// returns the number of steps done when searching a proof as well as a
     /// `Proof` if a suitable candidate tuple is found, otherwise `None`.
-    fn prove_routine(
-        set_size: u64,
-        params: &Params,
-        prover_set: &[Element],
-    ) -> (u64, Option<Proof>) {
+    fn prove_routine(set_size: u64, params: &Params, prover_set: &[E]) -> (u64, Option<Proof<E>>) {
         let mut steps: u64 = 0;
 
         // Run prove_index up to max_retries times
@@ -121,14 +117,15 @@ impl Proof {
         }
 
         // Initialise a round with given retry and search counters
-        let Some(mut round) = Round::new(self.retry_counter, self.search_counter, set_size) else {
+        let Some(mut round) = Round::<E>::new(self.retry_counter, self.search_counter, set_size)
+        else {
             return false;
         };
 
         // For each element in the proof's sequence
-        for &element in &self.element_sequence {
+        for element in &self.element_sequence {
             // Retrieve the bin id associated to this new element
-            let Some(bin_id) = Proof::bin_hash(set_size, self.retry_counter, element) else {
+            let Some(bin_id) = Self::bin_hash(set_size, self.retry_counter, element) else {
                 return false;
             };
             // Check that the new element was chosen correctly
@@ -151,21 +148,21 @@ impl Proof {
     fn prove_index(
         set_size: u64,
         params: &Params,
-        prover_set: &[Element],
+        prover_set: &[E],
         retry_counter: u64,
     ) -> (u64, Option<Self>) {
         // Initialize set_size bins
-        let mut bins: Vec<Vec<Element>> = Vec::with_capacity(set_size as usize);
+        let mut bins = Vec::with_capacity(set_size as usize);
         for _ in 0..set_size {
             bins.push(Vec::new());
         }
 
         // Take only up to 2*set_size elements for efficiency and fill the bins
         // with them
-        for &element in prover_set.iter().take(set_size.saturating_mul(2) as usize) {
-            match Proof::bin_hash(set_size, retry_counter, element) {
+        for element in prover_set.iter().take(set_size.saturating_mul(2) as usize) {
+            match Self::bin_hash(set_size, retry_counter, element) {
                 Some(bin_index) => {
-                    bins[bin_index as usize].push(element);
+                    bins[bin_index as usize].push(element.clone());
                 }
                 None => return (0, None),
             }
@@ -202,8 +199,8 @@ impl Proof {
     /// - proof_hash(round_hash(... round_hash((round_hash(v, t), x_1), ..., x_u)) = true
     fn dfs(
         params: &Params,
-        bins: &[Vec<Element>],
-        round: &Round,
+        bins: &[Vec<E>],
+        round: &Round<E>,
         mut step: u64,
     ) -> (u64, Option<Self>) {
         // If current round comprises params.proof_size elements and satisfies
@@ -222,7 +219,7 @@ impl Proof {
         }
 
         // For each element in bin numbered id
-        for &element in &bins[round.id as usize] {
+        for element in &bins[round.id as usize] {
             // If DFS was called more than params.dfs_bound times, abort this
             // round
             if step == params.dfs_bound {
@@ -246,19 +243,19 @@ impl Proof {
 
     /// Oracle producing a uniformly random value in [0, set_size[ used for
     /// prehashing S_p
-    fn bin_hash(set_size: u64, retry_counter: u64, element: Element) -> Option<u64> {
+    fn bin_hash(set_size: u64, retry_counter: u64, element: &E) -> Option<u64> {
         let retry_bytes: [u8; 8] = retry_counter.to_be_bytes();
         let mut hasher = Blake2s256::new();
         hasher.update(b"Telescope-bin_hash");
         hasher.update(retry_bytes);
-        hasher.update(element);
+        hasher.update(element.to_be_bytes());
         let digest: Hash = hasher.finalize().into();
         sample::sample_uniform(&digest, set_size)
     }
 
     /// Oracle defined as Bernoulli(q) returning 1 with probability q and 0
     /// otherwise
-    fn proof_hash(valid_proof_probability: f64, r: &Round) -> bool {
+    fn proof_hash(valid_proof_probability: f64, r: &Round<E>) -> bool {
         let mut hasher = Blake2s256::new();
         hasher.update(b"Telescope-proof_hash");
         hasher.update(r.hash);

--- a/src/centralized_telescope/proof.rs
+++ b/src/centralized_telescope/proof.rs
@@ -18,7 +18,7 @@ pub struct Proof<E> {
     pub element_sequence: Vec<E>,
 }
 
-impl<E: AsRef<[u8]> + Clone + Ord> Proof<E> {
+impl<E: AsRef<[u8]> + Clone> Proof<E> {
     /// Centralized Telescope's proving algorithm, based on a DFS algorithm.
     /// Calls up to `params.max_retries` times the prove_index function and
     /// returns a `Proof` if a suitable candidate tuple is found.

--- a/src/centralized_telescope/proof.rs
+++ b/src/centralized_telescope/proof.rs
@@ -4,15 +4,12 @@
 
 use super::params::Params;
 use super::round::Round;
-use crate::utils::{
-    sample,
-    types::{Hash, ToBytes},
-};
+use crate::utils::{sample, types::Hash};
 use blake2::{Blake2s256, Digest};
 
 /// Centralized Telescope proof
 #[derive(Debug, Clone)]
-pub struct Proof<E: ToBytes + Clone + Sized + Ord> {
+pub struct Proof<E: AsRef<[u8]> + Clone + Ord> {
     /// Numbers of retries done to find the proof
     pub retry_counter: u64,
     /// Index of the searched subtree to find the proof
@@ -21,7 +18,7 @@ pub struct Proof<E: ToBytes + Clone + Sized + Ord> {
     pub element_sequence: Vec<E>,
 }
 
-impl<E: ToBytes + Clone + Sized + Ord> Proof<E> {
+impl<E: AsRef<[u8]> + Clone + Ord> Proof<E> {
     /// Centralized Telescope's proving algorithm, based on a DFS algorithm.
     /// Calls up to `params.max_retries` times the prove_index function and
     /// returns a `Proof` if a suitable candidate tuple is found.
@@ -248,7 +245,7 @@ impl<E: ToBytes + Clone + Sized + Ord> Proof<E> {
         let mut hasher = Blake2s256::new();
         hasher.update(b"Telescope-bin_hash");
         hasher.update(retry_bytes);
-        hasher.update(element.to_be_bytes());
+        hasher.update(element.as_ref());
         let digest: Hash = hasher.finalize().into();
         sample::sample_uniform(&digest, set_size)
     }

--- a/src/centralized_telescope/round.rs
+++ b/src/centralized_telescope/round.rs
@@ -2,15 +2,12 @@
 
 #![doc = include_str!("../../docs/rustdoc/centralized_telescope/round.md")]
 
-use crate::utils::{
-    sample,
-    types::{Hash, ToBytes},
-};
+use crate::utils::{sample, types::Hash};
 use blake2::{Blake2s256, Digest};
 
 /// Round parameters
 #[derive(Debug, Clone)]
-pub struct Round<E: ToBytes + Clone + Sized + Ord> {
+pub struct Round<E: AsRef<[u8]> + Clone + Ord> {
     /// Numbers of retries done so far
     pub retry_counter: u64,
     /// Index of the current subtree being searched
@@ -25,7 +22,7 @@ pub struct Round<E: ToBytes + Clone + Sized + Ord> {
     pub set_size: u64,
 }
 
-impl<E: ToBytes + Clone + Sized + Ord> Round<E> {
+impl<E: AsRef<[u8]> + Clone + Ord> Round<E> {
     /// Output a round from retry and search counters as well as set_size
     /// Initilialises the hash with round_hash(retry_counter || search_bytes)
     /// and random value as oracle(round_hash(retry_counter || search_bytes), set_size)
@@ -48,7 +45,7 @@ impl<E: ToBytes + Clone + Sized + Ord> Round<E> {
     pub(super) fn update(r: &Self, element: &E) -> Option<Self> {
         let mut element_sequence = r.element_sequence.clone();
         element_sequence.push(element.clone());
-        let (hash, id_opt) = Self::round_hash(&r.hash, element.to_be_bytes().as_ref(), r.set_size);
+        let (hash, id_opt) = Self::round_hash(&r.hash, element.as_ref(), r.set_size);
         id_opt.map(|id| Self {
             retry_counter: r.retry_counter,
             search_counter: r.search_counter,

--- a/src/centralized_telescope/round.rs
+++ b/src/centralized_telescope/round.rs
@@ -4,19 +4,19 @@
 
 use crate::utils::{
     sample,
-    types::{Element, Hash},
+    types::{Hash, ToBytes},
 };
 use blake2::{Blake2s256, Digest};
 
 /// Round parameters
 #[derive(Debug, Clone)]
-pub struct Round {
+pub struct Round<E: ToBytes + Clone + Sized + Ord> {
     /// Numbers of retries done so far
     pub retry_counter: u64,
     /// Index of the current subtree being searched
     pub search_counter: u64,
     /// Candidate element sequence
-    pub element_sequence: Vec<Element>,
+    pub element_sequence: Vec<E>,
     /// Candidate round hash
     pub hash: Hash,
     /// Candidate round id, i.e. round hash mapped to [1, set_size]
@@ -25,7 +25,7 @@ pub struct Round {
     pub set_size: u64,
 }
 
-impl Round {
+impl<E: ToBytes + Clone + Sized + Ord> Round<E> {
     /// Output a round from retry and search counters as well as set_size
     /// Initilialises the hash with round_hash(retry_counter || search_bytes)
     /// and random value as oracle(round_hash(retry_counter || search_bytes), set_size)
@@ -45,10 +45,10 @@ impl Round {
 
     /// Updates a round with an element
     /// Replaces the hash $h$ with $h' = round_hash(h, s)$ and the random value as oracle(h', set_size)
-    pub(super) fn update(r: &Self, element: Element) -> Option<Self> {
+    pub(super) fn update(r: &Self, element: &E) -> Option<Self> {
         let mut element_sequence = r.element_sequence.clone();
-        element_sequence.push(element);
-        let (hash, id_opt) = Self::round_hash(&r.hash, &element, r.set_size);
+        element_sequence.push(element.clone());
+        let (hash, id_opt) = Self::round_hash(&r.hash, element.to_be_bytes().as_ref(), r.set_size);
         id_opt.map(|id| Self {
             retry_counter: r.retry_counter,
             search_counter: r.search_counter,

--- a/src/centralized_telescope/round.rs
+++ b/src/centralized_telescope/round.rs
@@ -7,7 +7,7 @@ use blake2::{Blake2s256, Digest};
 
 /// Round parameters
 #[derive(Debug, Clone)]
-pub struct Round<E: AsRef<[u8]> + Clone + Ord> {
+pub struct Round<E> {
     /// Numbers of retries done so far
     pub retry_counter: u64,
     /// Index of the current subtree being searched

--- a/src/centralized_telescope/round.rs
+++ b/src/centralized_telescope/round.rs
@@ -22,7 +22,7 @@ pub struct Round<E> {
     pub set_size: u64,
 }
 
-impl<E: AsRef<[u8]> + Clone + Ord> Round<E> {
+impl<E: AsRef<[u8]> + Clone> Round<E> {
     /// Output a round from retry and search counters as well as set_size
     /// Initilialises the hash with round_hash(retry_counter || search_bytes)
     /// and random value as oracle(round_hash(retry_counter || search_bytes), set_size)

--- a/src/centralized_telescope/telescope.rs
+++ b/src/centralized_telescope/telescope.rs
@@ -1,7 +1,6 @@
 //! Customer facing Centralized Telescope structure
 use super::params::Params;
 use super::proof::Proof;
-use crate::utils::types::ToBytes;
 
 /// The main centralized Telescope struct with prove and verify functions.
 #[derive(Debug, Clone, Copy)]
@@ -138,7 +137,7 @@ impl Telescope {
     /// }
     /// let proof = telescope.prove(&prover_set).unwrap();
     /// ```
-    pub fn prove<E: ToBytes + Clone + Sized + Ord>(&self, prover_set: &[E]) -> Option<Proof<E>> {
+    pub fn prove<E: AsRef<[u8]> + Clone + Ord>(&self, prover_set: &[E]) -> Option<Proof<E>> {
         Proof::new(self.set_size, &self.params, prover_set)
     }
 
@@ -166,7 +165,7 @@ impl Telescope {
     /// let proof = telescope.prove(&prover_set).unwrap();
     /// assert!(telescope.verify(&proof));
     /// ```
-    pub fn verify<E: ToBytes + Clone + Sized + Ord>(&self, proof: &Proof<E>) -> bool {
+    pub fn verify<E: AsRef<[u8]> + Clone + Ord>(&self, proof: &Proof<E>) -> bool {
         proof.verify(self.set_size, &self.params)
     }
 }

--- a/src/centralized_telescope/telescope.rs
+++ b/src/centralized_telescope/telescope.rs
@@ -1,7 +1,7 @@
 //! Customer facing Centralized Telescope structure
 use super::params::Params;
 use super::proof::Proof;
-use crate::utils::types::Element;
+use crate::utils::types::ToBytes;
 
 /// The main centralized Telescope struct with prove and verify functions.
 #[derive(Debug, Clone, Copy)]
@@ -138,7 +138,7 @@ impl Telescope {
     /// }
     /// let proof = telescope.prove(&prover_set).unwrap();
     /// ```
-    pub fn prove(&self, prover_set: &[Element]) -> Option<Proof> {
+    pub fn prove<E: ToBytes + Clone + Sized + Ord>(&self, prover_set: &[E]) -> Option<Proof<E>> {
         Proof::new(self.set_size, &self.params, prover_set)
     }
 
@@ -166,7 +166,7 @@ impl Telescope {
     /// let proof = telescope.prove(&prover_set).unwrap();
     /// assert!(telescope.verify(&proof));
     /// ```
-    pub fn verify(&self, proof: &Proof) -> bool {
+    pub fn verify<E: ToBytes + Clone + Sized + Ord>(&self, proof: &Proof<E>) -> bool {
         proof.verify(self.set_size, &self.params)
     }
 }

--- a/src/centralized_telescope/telescope.rs
+++ b/src/centralized_telescope/telescope.rs
@@ -137,7 +137,7 @@ impl Telescope {
     /// }
     /// let proof = telescope.prove(&prover_set).unwrap();
     /// ```
-    pub fn prove<E: AsRef<[u8]> + Clone + Ord>(&self, prover_set: &[E]) -> Option<Proof<E>> {
+    pub fn prove<E: AsRef<[u8]> + Clone>(&self, prover_set: &[E]) -> Option<Proof<E>> {
         Proof::new(self.set_size, &self.params, prover_set)
     }
 
@@ -165,7 +165,7 @@ impl Telescope {
     /// let proof = telescope.prove(&prover_set).unwrap();
     /// assert!(telescope.verify(&proof));
     /// ```
-    pub fn verify<E: AsRef<[u8]> + Clone + Ord>(&self, proof: &Proof<E>) -> bool {
+    pub fn verify<E: AsRef<[u8]> + Clone>(&self, proof: &Proof<E>) -> bool {
         proof.verify(self.set_size, &self.params)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
-mod utils;
+pub mod utils;
 
 pub mod centralized_telescope;
 pub mod simple_lottery;

--- a/src/simple_lottery/lottery.rs
+++ b/src/simple_lottery/lottery.rs
@@ -106,7 +106,7 @@ impl Lottery {
     /// }
     /// let proof = lottery.prove(&prover_set).unwrap();
     /// ```
-    pub fn prove<E: AsRef<[u8]> + Clone + Ord>(&self, prover_set: &[E]) -> Option<Proof<E>> {
+    pub fn prove<E: AsRef<[u8]> + Clone>(&self, prover_set: &[E]) -> Option<Proof<E>> {
         Proof::new(&self.params, prover_set)
     }
 
@@ -134,7 +134,7 @@ impl Lottery {
     /// let proof = lottery.prove(&prover_set).unwrap();
     /// assert!(lottery.verify(&proof));
     /// ```
-    pub fn verify<E: AsRef<[u8]> + Clone + Ord>(&self, proof: &Proof<E>) -> bool {
+    pub fn verify<E: AsRef<[u8]> + Clone>(&self, proof: &Proof<E>) -> bool {
         proof.verify(&self.params)
     }
 }

--- a/src/simple_lottery/lottery.rs
+++ b/src/simple_lottery/lottery.rs
@@ -1,7 +1,7 @@
 //! Customer facing Lottery structure
 use super::params::Params;
 use super::proof::Proof;
-use crate::utils::types::Element;
+use crate::utils::types::ToBytes;
 
 /// The main simple lottery struct with prove and verify functions.
 #[derive(Debug, Clone, Copy)]
@@ -107,7 +107,7 @@ impl Lottery {
     /// }
     /// let proof = lottery.prove(&prover_set).unwrap();
     /// ```
-    pub fn prove(&self, prover_set: &[Element]) -> Option<Proof> {
+    pub fn prove<E: ToBytes + Clone + Sized + Ord>(&self, prover_set: &[E]) -> Option<Proof<E>> {
         Proof::new(&self.params, prover_set)
     }
 
@@ -135,7 +135,7 @@ impl Lottery {
     /// let proof = lottery.prove(&prover_set).unwrap();
     /// assert!(lottery.verify(&proof));
     /// ```
-    pub fn verify(&self, proof: &Proof) -> bool {
+    pub fn verify<E: ToBytes + Clone + Sized + Ord>(&self, proof: &Proof<E>) -> bool {
         proof.verify(&self.params)
     }
 }

--- a/src/simple_lottery/lottery.rs
+++ b/src/simple_lottery/lottery.rs
@@ -1,7 +1,6 @@
 //! Customer facing Lottery structure
 use super::params::Params;
 use super::proof::Proof;
-use crate::utils::types::ToBytes;
 
 /// The main simple lottery struct with prove and verify functions.
 #[derive(Debug, Clone, Copy)]
@@ -107,7 +106,7 @@ impl Lottery {
     /// }
     /// let proof = lottery.prove(&prover_set).unwrap();
     /// ```
-    pub fn prove<E: ToBytes + Clone + Sized + Ord>(&self, prover_set: &[E]) -> Option<Proof<E>> {
+    pub fn prove<E: AsRef<[u8]> + Clone + Ord>(&self, prover_set: &[E]) -> Option<Proof<E>> {
         Proof::new(&self.params, prover_set)
     }
 
@@ -135,7 +134,7 @@ impl Lottery {
     /// let proof = lottery.prove(&prover_set).unwrap();
     /// assert!(lottery.verify(&proof));
     /// ```
-    pub fn verify<E: ToBytes + Clone + Sized + Ord>(&self, proof: &Proof<E>) -> bool {
+    pub fn verify<E: AsRef<[u8]> + Clone + Ord>(&self, proof: &Proof<E>) -> bool {
         proof.verify(&self.params)
     }
 }

--- a/src/simple_lottery/proof.rs
+++ b/src/simple_lottery/proof.rs
@@ -10,7 +10,7 @@ pub struct Proof<E> {
     pub element_sequence: Vec<E>,
 }
 
-impl<E: AsRef<[u8]> + Clone + Ord> Proof<E> {
+impl<E: AsRef<[u8]> + Clone> Proof<E> {
     /// Simple Lottery's proving algorithm, based on a DFS algorithm.
     ///
     /// # Arguments
@@ -44,7 +44,7 @@ impl<E: AsRef<[u8]> + Clone + Ord> Proof<E> {
                 element_sequence.push(element.clone());
             }
             if element_sequence.len() as u64 >= params.proof_size {
-                element_sequence.sort_unstable();
+                element_sequence.sort_unstable_by(|a, b: &E| a.as_ref().cmp(b.as_ref()));
                 return Some(Proof { element_sequence });
             }
         }
@@ -80,7 +80,9 @@ impl<E: AsRef<[u8]> + Clone + Ord> Proof<E> {
     /// ```
     pub fn verify(&self, params: &Params) -> bool {
         (self.element_sequence.len() as u64 == params.proof_size)
-            && self.element_sequence.is_sorted_by(|a, b| a < b)
+            && self
+                .element_sequence
+                .is_sorted_by(|a, b| a.as_ref() < b.as_ref())
             && self
                 .element_sequence
                 .iter()

--- a/src/simple_lottery/proof.rs
+++ b/src/simple_lottery/proof.rs
@@ -5,7 +5,7 @@ use blake2::{Blake2s256, Digest};
 
 /// Simple lottery proof
 #[derive(Debug, Clone)]
-pub struct Proof<E: AsRef<[u8]> + Clone + Ord> {
+pub struct Proof<E> {
     /// Sequence of elements from prover's set
     pub element_sequence: Vec<E>,
 }

--- a/src/simple_lottery/proof.rs
+++ b/src/simple_lottery/proof.rs
@@ -1,19 +1,16 @@
 //! Simple Lottery's Proof structure
 use super::params::Params;
-use crate::utils::{
-    sample,
-    types::{Hash, ToBytes},
-};
+use crate::utils::{sample, types::Hash};
 use blake2::{Blake2s256, Digest};
 
 /// Simple lottery proof
 #[derive(Debug, Clone)]
-pub struct Proof<E: ToBytes + Clone + Sized + Ord> {
+pub struct Proof<E: AsRef<[u8]> + Clone + Ord> {
     /// Sequence of elements from prover's set
     pub element_sequence: Vec<E>,
 }
 
-impl<E: ToBytes + Clone + Sized + Ord> Proof<E> {
+impl<E: AsRef<[u8]> + Clone + Ord> Proof<E> {
     /// Simple Lottery's proving algorithm, based on a DFS algorithm.
     ///
     /// # Arguments
@@ -94,7 +91,7 @@ impl<E: ToBytes + Clone + Sized + Ord> Proof<E> {
     /// otherwise
     fn lottery_hash(lottery_probability: f64, element: &E) -> bool {
         let mut hasher = Blake2s256::new();
-        hasher.update(element.to_be_bytes());
+        hasher.update(element.as_ref());
         let digest: Hash = hasher.finalize().into();
         sample::sample_bernoulli(&digest, lottery_probability)
     }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,7 +1,7 @@
-use super::types::Element;
+use super::types::ToBytes;
 
 /// Returns true iff all elements in the slice are distinct.
-pub(crate) fn check_distinct(elements: &[Element]) -> bool {
+pub(crate) fn check_distinct<E: ToBytes + Clone + Sized + Ord>(elements: &[E]) -> bool {
     let mut elements = elements.to_vec();
     elements.sort_unstable();
     elements.is_sorted_by(|a, b| a < b)

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,6 +1,6 @@
 /// Returns true iff all elements in the slice are distinct.
-pub(crate) fn check_distinct<E: AsRef<[u8]> + Clone + Ord>(elements: &[E]) -> bool {
+pub(crate) fn check_distinct<E: AsRef<[u8]> + Clone>(elements: &[E]) -> bool {
     let mut elements = elements.to_vec();
-    elements.sort_unstable();
-    elements.is_sorted_by(|a, b| a < b)
+    elements.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+    elements.is_sorted_by(|a, b| a.as_ref() < b.as_ref())
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,7 +1,5 @@
-use super::types::ToBytes;
-
 /// Returns true iff all elements in the slice are distinct.
-pub(crate) fn check_distinct<E: ToBytes + Clone + Sized + Ord>(elements: &[E]) -> bool {
+pub(crate) fn check_distinct<E: AsRef<[u8]> + Clone + Ord>(elements: &[E]) -> bool {
     let mut elements = elements.to_vec();
     elements.sort_unstable();
     elements.is_sorted_by(|a, b| a < b)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,7 @@
+//! Shared utility functions
+
 pub(crate) mod sample;
 
-pub(crate) mod types;
+pub mod types;
 
 pub(crate) mod misc;

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,45 +1,7 @@
 //! Types and implementation
-use std::mem;
 
 /// Digest size for internal hashes
 pub(crate) const DIGEST_SIZE: usize = 32;
 
 /// Hash type for internal hashes
 pub(crate) type Hash = [u8; DIGEST_SIZE];
-
-/// Trait to represent input as bytes
-pub trait ToBytes {
-    /// Reference on unsized array of u8
-    type ByteArray: AsRef<[u8]>;
-    /// Returns the byte representation of the element
-    fn to_be_bytes(&self) -> Self::ByteArray;
-}
-
-// Implementing ToBytes for integer types
-macro_rules! impl_ToBytes {
-    (for $($t:ty),+) => {
-        $(impl ToBytes for $t {
-            type ByteArray = [u8; mem::size_of::<Self>()];
-
-            fn to_be_bytes(&self) -> Self::ByteArray {
-                return Self::to_be_bytes(*self);
-            }
-        })*
-    }
-}
-impl_ToBytes!(for u8, u16, u32, u64, u128);
-impl_ToBytes!(for i8, i16, i32, i64, i128);
-
-// Implementing ToBytes for byte arrays
-macro_rules! impl_u8ToBytes {
-    (for $($t:ty),+) => {
-        $(impl ToBytes for $t {
-            type ByteArray = Self;
-
-            fn to_be_bytes(&self) -> Self::ByteArray {
-                *self
-            }
-        })*
-    }
-}
-impl_u8ToBytes!(for [u8;32], [u8;48], [u8;64], [u8;128], [u8;448]);

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,10 +1,45 @@
-pub(crate) const DATA_LENGTH: usize = 48;
-
-/// Type of dataset's elements to lower bound
-pub(crate) type Element = [u8; DATA_LENGTH];
+//! Types and implementation
+use std::mem;
 
 /// Digest size for internal hashes
 pub(crate) const DIGEST_SIZE: usize = 32;
 
 /// Hash type for internal hashes
 pub(crate) type Hash = [u8; DIGEST_SIZE];
+
+/// Trait to represent input as bytes
+pub trait ToBytes {
+    /// Reference on unsized array of u8
+    type ByteArray: AsRef<[u8]>;
+    /// Returns the byte representation of the element
+    fn to_be_bytes(&self) -> Self::ByteArray;
+}
+
+// Implementing ToBytes for integer types
+macro_rules! impl_ToBytes {
+    (for $($t:ty),+) => {
+        $(impl ToBytes for $t {
+            type ByteArray = [u8; mem::size_of::<Self>()];
+
+            fn to_be_bytes(&self) -> Self::ByteArray {
+                return Self::to_be_bytes(*self);
+            }
+        })*
+    }
+}
+impl_ToBytes!(for u8, u16, u32, u64, u128);
+impl_ToBytes!(for i8, i16, i32, i64, i128);
+
+// Implementing ToBytes for byte arrays
+macro_rules! impl_u8ToBytes {
+    (for $($t:ty),+) => {
+        $(impl ToBytes for $t {
+            type ByteArray = Self;
+
+            fn to_be_bytes(&self) -> Self::ByteArray {
+                *self
+            }
+        })*
+    }
+}
+impl_u8ToBytes!(for [u8;32], [u8;48], [u8;64], [u8;128], [u8;448]);

--- a/tests/centralized_telescope.rs
+++ b/tests/centralized_telescope.rs
@@ -9,6 +9,7 @@ mod common;
 use common::gen_items;
 
 const DATA_LENGTH: usize = 48;
+type Data = [u8; DATA_LENGTH];
 
 fn test(created_with_params: bool) {
     let mut rng = ChaCha20Rng::from_seed(Default::default());
@@ -20,7 +21,7 @@ fn test(created_with_params: bool) {
     let lower_bound = nb_elements.saturating_mul(20).div_ceil(100);
     for _t in 0..nb_tests {
         let seed = rng.next_u32().to_be_bytes().to_vec();
-        let s_p = gen_items::<DATA_LENGTH>(&seed, nb_elements);
+        let s_p: Vec<Data> = gen_items::<DATA_LENGTH>(&seed, nb_elements);
         let alba = if created_with_params {
             Telescope::create(soundness_param, completeness_param, set_size, lower_bound)
         } else {
@@ -47,7 +48,7 @@ fn test(created_with_params: bool) {
         let proof_item = Proof {
             retry_counter: proof.retry_counter,
             search_counter: proof.search_counter,
-            element_sequence: Vec::new(),
+            element_sequence: Vec::<Data>::new(),
         };
         assert!(!alba.verify(&proof_item));
         // Checking that the proof fails when wrong elements are included


### PR DESCRIPTION
## Content

So far, we could only use Element as input type. This was fixed to a byte array of a specific size for the whole repository.

This PR aims at supporting mroe input types, and allowing the use of different input types across examples and tests.

To do so, I have created a `ToBytes` trait and updating the relevant struct and functions to use a generic type implementing it. The hash functions then only have to call `to_be_bytes()` that is the one function defined in the trait.

I have also written some macros to implement `ToBytes`, and so support, some standard types.

## Pre-submit checklist

- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
- PR
    - [x] No clippy warnings in the CI
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- Documentation
    - [x] Update README file (if relevant)
    - [x] Update documentation website (if relevant)

## Comments

We should be able to support both BLS and KES (with current Cardano params) signatures.

## Issue(s)

Relates to #30 